### PR TITLE
Add missing runtime error translations for Python

### DIFF
--- a/src/python/locales/en/translation.json
+++ b/src/python/locales/en/translation.json
@@ -31,12 +31,19 @@
     },
     "runtime": {
       "FunctionExecutionError": "Error executing function '{{function}}': {{message}}",
+      "FunctionNotFound": "The function '{{name}}' is not defined.",
+      "IndexError": "Index {{index}} is out of range. The list has {{length}} elements.",
       "InvalidBinaryExpression": "Invalid binary operation between these values.",
+      "InvalidNumberOfArguments": "Function expected {{expected}} argument(s), but received {{received}}.",
       "InvalidUnaryExpression": "Invalid unary operation on this value.",
+      "LogicErrorInExecution": "Internal error: {{message}}",
+      "NodeNotAllowed": "The '{{nodeType}}' feature is not allowed in this exercise.",
+      "ReturnOutsideFunction": "Return statement cannot be used outside of a function.",
       "TruthinessDisabled": "Cannot use {{value}} as a boolean value. Only boolean values are allowed in conditions when truthiness is disabled.",
+      "TypeCoercionNotAllowed": "Cannot perform {{operation}} between {{leftType}} and {{rightType}}. Type coercion is disabled.",
+      "TypeError": "{{message}}",
       "UndefinedVariable": "Undefined variable referenced in code.",
-      "UnsupportedOperation": "This operation is not supported.",
-      "ReturnOutsideFunction": "Return statement cannot be used outside of a function."
+      "UnsupportedOperation": "This operation is not supported."
     }
   }
 }

--- a/src/python/locales/system/translation.json
+++ b/src/python/locales/system/translation.json
@@ -31,12 +31,19 @@
     },
     "runtime": {
       "FunctionExecutionError": "FunctionExecutionError: function: {{function}}: message: {{message}}",
+      "FunctionNotFound": "FunctionNotFound: name: {{name}}",
+      "IndexError": "IndexError: index: {{index}}: length: {{length}}",
       "InvalidBinaryExpression": "InvalidBinaryExpression",
+      "InvalidNumberOfArguments": "InvalidNumberOfArguments: expected: {{expected}}: received: {{received}}",
       "InvalidUnaryExpression": "InvalidUnaryExpression",
+      "LogicErrorInExecution": "LogicErrorInExecution: message: {{message}}",
+      "NodeNotAllowed": "NodeNotAllowed: nodeType: {{nodeType}}",
+      "ReturnOutsideFunction": "ReturnOutsideFunction",
       "TruthinessDisabled": "TruthinessDisabled: value: {{value}}",
+      "TypeCoercionNotAllowed": "TypeCoercionNotAllowed: operation: {{operation}}: leftType: {{leftType}}: rightType: {{rightType}}",
+      "TypeError": "TypeError: message: {{message}}",
       "UndefinedVariable": "UndefinedVariable: name: {{name}}",
-      "UnsupportedOperation": "UnsupportedOperation",
-      "ReturnOutsideFunction": "ReturnOutsideFunction"
+      "UnsupportedOperation": "UnsupportedOperation"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds missing runtime error translations for Python to achieve parity with JavaScript error message quality.

## Changes

Added translations for 7 runtime error types that were implemented but missing translations:

**System translations (src/python/locales/system/translation.json):**
- TypeError
- TypeCoercionNotAllowed
- IndexError
- NodeNotAllowed
- FunctionNotFound
- InvalidNumberOfArguments
- LogicErrorInExecution

**Human-readable translations (src/python/locales/en/translation.json):**
- Educational, beginner-friendly error messages
- Consistent with JavaScript interpreter error style
- Context-specific parameter interpolation

## Impact

- All 14 RuntimeErrorType errors now have complete translations
- Users will see proper error messages instead of untranslated error type keys
- Brings Python to parity with JavaScript for error message quality
- Alphabetized for maintainability

## Testing

- All 456 Python tests pass ✅
- All 1931 total tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)