### PR TITLE
feat(js): Add string stdlib support with length and charAt

### DIFF
--- a/src/javascript/executor/executeStdlibMemberExpression.ts
+++ b/src/javascript/executor/executeStdlibMemberExpression.ts
@@ -31,13 +31,13 @@ export function executeStdlibMemberExpression(
   // Check if it's a property
   const stdlibProperty = stdlib[stdlibType].properties[propertyName] as Property | undefined;
   if (stdlibProperty) {
-    return handleProperty(stdlibProperty, stdlibType, propertyName, objectResult, propertyResult, object);
+    return handleProperty(stdlibProperty);
   }
 
   // Check if it's a method
   const stdlibMethod = stdlib[stdlibType].methods[propertyName] as Method | undefined;
   if (stdlibMethod) {
-    return handleMethod(stdlibMethod, stdlibType, propertyName, objectResult, propertyResult, object);
+    return handleMethod(stdlibMethod);
   }
 
   // Unknown property/method
@@ -46,14 +46,7 @@ export function executeStdlibMemberExpression(
   });
 
   // Helper function to handle property access
-  function handleProperty(
-    stdlibProperty: Property,
-    stdlibType: string,
-    propertyName: string,
-    objectResult: EvaluationResult,
-    propertyResult: EvaluationResult,
-    object: JikiObject
-  ): EvaluationResultMemberExpression {
+  function handleProperty(stdlibProperty: Property): EvaluationResultMemberExpression {
     guardPropertyIsNotStub(stdlibProperty, propertyName);
     guardPropertyIsAllowed(stdlibType, propertyName);
 
@@ -72,14 +65,7 @@ export function executeStdlibMemberExpression(
   }
 
   // Helper function to handle method access
-  function handleMethod(
-    stdlibMethod: Method,
-    stdlibType: string,
-    propertyName: string,
-    objectResult: EvaluationResult,
-    propertyResult: EvaluationResult,
-    object: JikiObject
-  ): EvaluationResultMemberExpression {
+  function handleMethod(stdlibMethod: Method): EvaluationResultMemberExpression {
     // Note: For stub methods, we still return a function, but it will throw when called
     // This maintains the correct semantics where arr.push returns a function
     guardMethodIsAllowed(stdlibType, propertyName);

--- a/src/javascript/executor/executeStdlibMemberExpression.ts
+++ b/src/javascript/executor/executeStdlibMemberExpression.ts
@@ -18,14 +18,7 @@ export function executeStdlibMemberExpression(
 
   // Check if this is computed access (bracket notation)
   // Stdlib members should only be accessed via dot notation
-  if (expression.computed) {
-    throw new RuntimeError(
-      `TypeError: message: Cannot use computed property access for stdlib members`,
-      expression.location,
-      "TypeError",
-      { message: "Cannot use computed property access for stdlib members" }
-    );
-  }
+  guardNotComputedAccess();
 
   // Evaluate the property to get its name
   const propertyResult = executor.evaluate(expression.property);
@@ -125,6 +118,19 @@ export function executeStdlibMemberExpression(
       expression.location,
       "TypeError",
       { message: `Cannot read properties of ${object.type}` }
+    );
+  }
+
+  function guardNotComputedAccess() {
+    if (!expression.computed) {
+      return;
+    }
+
+    throw new RuntimeError(
+      `TypeError: message: Cannot use computed property access for stdlib members`,
+      expression.location,
+      "TypeError",
+      { message: "Cannot use computed property access for stdlib members" }
     );
   }
 

--- a/src/javascript/stdlib/index.ts
+++ b/src/javascript/stdlib/index.ts
@@ -1,4 +1,5 @@
 import { arrayProperties, arrayMethods } from "./arrays";
+import { stringProperties, stringMethods } from "./strings";
 import type { JikiObject } from "../jsObjects";
 import type { ExecutionContext } from "../executor";
 import type { LanguageFeatures } from "../interfaces";
@@ -29,6 +30,10 @@ export const stdlib: Record<string, StdlibType> = {
     properties: arrayProperties,
     methods: arrayMethods,
   },
+  string: {
+    properties: stringProperties,
+    methods: stringMethods,
+  },
 };
 
 // Get the stdlib type for a JikiObject
@@ -37,7 +42,9 @@ export function getStdlibType(obj: JikiObject): string | null {
   if (obj.type === "list") {
     return "array";
   }
-  // Future: if (obj.type === "string") return "string";
+  if (obj.type === "string") {
+    return "string";
+  }
   // Future: if (obj.type === "number") return "number";
   return null;
 }

--- a/src/javascript/stdlib/strings.ts
+++ b/src/javascript/stdlib/strings.ts
@@ -1,0 +1,104 @@
+import { JSString, JSNumber, type JikiObject } from "../jsObjects";
+import type { ExecutionContext } from "../executor";
+import type { Property, Method } from "./index";
+import { StdlibError, createNotYetImplementedStub } from "./index";
+
+// String properties
+export const stringProperties: Record<string, Property> = {
+  length: {
+    get: (_ctx: ExecutionContext, obj: JikiObject) => {
+      const string = obj as JSString;
+      return new JSNumber(string.value.length);
+    },
+    description: "the number of characters in the string",
+  },
+};
+
+// List of string methods that are not yet implemented
+const notYetImplementedMethods = [
+  // Accessor methods
+  "charCodeAt",
+  "codePointAt",
+  "indexOf",
+  "lastIndexOf",
+  "includes",
+  "startsWith",
+  "endsWith",
+  "slice",
+  "substring",
+  "substr",
+  "concat",
+  "split",
+  "match",
+  "search",
+  "replace",
+  "replaceAll",
+
+  // Case methods
+  "toLowerCase",
+  "toUpperCase",
+  "toLocaleLowerCase",
+  "toLocaleUpperCase",
+
+  // Trim methods
+  "trim",
+  "trimStart",
+  "trimEnd",
+  "trimLeft",
+  "trimRight",
+
+  // Padding methods
+  "padStart",
+  "padEnd",
+
+  // Other methods
+  "repeat",
+  "normalize",
+  "localeCompare",
+  "toString",
+  "valueOf",
+];
+
+// String methods
+export const stringMethods: Record<string, Method> = {
+  // Implemented methods
+  charAt: {
+    arity: 1,
+    call: (_ctx: ExecutionContext, obj: JikiObject, args: JikiObject[]) => {
+      const string = obj as JSString;
+      const indexArg = args[0];
+
+      // Check that the argument is a number
+      if (!(indexArg instanceof JSNumber)) {
+        throw new StdlibError("TypeError", `charAt() expects a number argument`, {
+          expectedType: "number",
+          receivedType: indexArg.type,
+        });
+      }
+
+      let index = indexArg.value;
+
+      // Check for non-integer indices
+      if (!Number.isInteger(index)) {
+        throw new StdlibError("TypeError", `charAt() expects an integer index`, { index });
+      }
+
+      // Handle negative indices (Python-style, for consistency with array.at)
+      if (index < 0) {
+        index = string.value.length + index;
+      }
+
+      // Check bounds - charAt returns empty string for out of bounds
+      if (index < 0 || index >= string.value.length) {
+        return new JSString("");
+      }
+
+      // Get the character
+      return new JSString(string.value[index]);
+    },
+    description: "returns the character at the specified index",
+  },
+
+  // Generate stub methods for all not-yet-implemented methods
+  ...Object.fromEntries(notYetImplementedMethods.map(name => [name, createNotYetImplementedStub(name)])),
+};

--- a/tests/javascript/string-properties-methods.test.ts
+++ b/tests/javascript/string-properties-methods.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test } from "vitest";
+import { interpret } from "../../src/javascript/interpreter";
+
+// Type for frames augmented in test environment
+interface TestAugmentedFrame {
+  status: "SUCCESS" | "ERROR";
+  result?: any;
+  variables?: Record<string, any>;
+  description?: string;
+  error?: {
+    type: string;
+    message?: string;
+    context?: any;
+  };
+}
+
+describe("String properties", () => {
+  describe("length property", () => {
+    test("returns correct length for simple string", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.length;
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(5);
+    });
+
+    test("returns 0 for empty string", () => {
+      const result = interpret(`
+        let str = "";
+        str.length;
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(0);
+    });
+
+    test("works with string containing spaces", () => {
+      const result = interpret(`
+        let str = "hello world";
+        str.length;
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(11);
+    });
+
+    test("works with string containing special characters", () => {
+      const result = interpret(`
+        let str = "hello\\nworld";
+        str.length;
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(11); // \n counts as 1 character
+    });
+
+    test("gives runtime error when using computed access for length", () => {
+      const result = interpret(`
+        let str = "hello";
+        str["length"];
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toBe(
+        "TypeError: message: Cannot use computed property access for stdlib members"
+      );
+    });
+
+    test("gives runtime error for unknown property", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.unknownProperty;
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("PropertyNotFound");
+      expect((errorFrame as TestAugmentedFrame)?.error?.context?.property).toBe("unknownProperty");
+    });
+  });
+});
+
+describe("String methods", () => {
+  describe("charAt method", () => {
+    test("returns character at positive index", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(0);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("h");
+    });
+
+    test("returns character at middle index", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(2);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("l");
+    });
+
+    test("returns character at last index", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(4);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("o");
+    });
+
+    test("supports negative indices", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(-1);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("o");
+    });
+
+    test("negative index from beginning", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(-5);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("h");
+    });
+
+    test("returns empty string for index out of bounds (positive)", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(10);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("");
+    });
+
+    test("returns empty string for index out of bounds (negative)", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(-10);
+      `);
+
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe("");
+    });
+
+    test("gives runtime error for non-number argument", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt("0");
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("TypeError");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("expects a number argument");
+    });
+
+    test("gives runtime error for non-integer index", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(1.5);
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("TypeError");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("expects an integer index");
+    });
+
+    test("gives runtime error for wrong number of arguments", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt();
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("InvalidNumberOfArguments");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("expected: 1");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("got: 0");
+    });
+
+    test("gives runtime error for too many arguments", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.charAt(0, 1);
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("InvalidNumberOfArguments");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("expected: 1");
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toContain("got: 2");
+    });
+  });
+
+  describe("unimplemented methods", () => {
+    test("gives runtime error for toLowerCase", () => {
+      const result = interpret(`
+        let str = "HELLO";
+        str.toLowerCase();
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("MethodNotYetImplemented");
+      expect((errorFrame as TestAugmentedFrame)?.error?.context?.method).toBe("toLowerCase");
+    });
+
+    test("gives runtime error for indexOf", () => {
+      const result = interpret(`
+        let str = "hello";
+        str.indexOf("l");
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("MethodNotYetImplemented");
+      expect((errorFrame as TestAugmentedFrame)?.error?.context?.method).toBe("indexOf");
+    });
+  });
+
+  describe("computed access", () => {
+    test("gives runtime error when using computed access for methods", () => {
+      const result = interpret(`
+        let str = "hello";
+        str["charAt"];
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(null);
+      const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect((errorFrame as TestAugmentedFrame)?.error?.message).toBe(
+        "TypeError: message: Cannot use computed property access for stdlib members"
+      );
+    });
+  });
+});
+
+describe("String stdlib with language features", () => {
+  test("restricts length property when not allowed", () => {
+    const result = interpret(
+      `
+      let str = "hello";
+      str.length;
+    `,
+      {
+        languageFeatures: {
+          allowedStdlib: {
+            string: {
+              properties: [], // No properties allowed
+              methods: ["charAt"],
+            },
+          },
+        },
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(null);
+    const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+    expect(errorFrame).toBeDefined();
+    expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("MethodNotYetAvailable");
+    expect((errorFrame as TestAugmentedFrame)?.error?.context?.method).toBe("length");
+  });
+
+  test("restricts charAt method when not allowed", () => {
+    const result = interpret(
+      `
+      let str = "hello";
+      str.charAt(0);
+    `,
+      {
+        languageFeatures: {
+          allowedStdlib: {
+            string: {
+              properties: ["length"],
+              methods: [], // No methods allowed
+            },
+          },
+        },
+      }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(null);
+    const errorFrame = result.frames.find(f => (f as TestAugmentedFrame).status === "ERROR");
+    expect(errorFrame).toBeDefined();
+    expect((errorFrame as TestAugmentedFrame)?.error?.type).toBe("MethodNotYetAvailable");
+    expect((errorFrame as TestAugmentedFrame)?.error?.context?.method).toBe("charAt");
+  });
+
+  test("allows length when included in feature flags", () => {
+    const result = interpret(
+      `
+      let str = "hello";
+      str.length;
+    `,
+      {
+        languageFeatures: {
+          allowedStdlib: {
+            string: {
+              properties: ["length"], // length is allowed
+              methods: [],
+            },
+          },
+        },
+      }
+    );
+
+    expect(result.error).toBe(null);
+    expect(result.success).toBe(true);
+    const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.status).toBe("SUCCESS");
+    expect(lastFrame.result?.jikiObject?.value).toBe(5);
+  });
+
+  test("allows charAt when included in feature flags", () => {
+    const result = interpret(
+      `
+      let str = "hello";
+      str.charAt(0);
+    `,
+      {
+        languageFeatures: {
+          allowedStdlib: {
+            string: {
+              properties: [],
+              methods: ["charAt"], // charAt is allowed
+            },
+          },
+        },
+      }
+    );
+
+    expect(result.error).toBe(null);
+    expect(result.success).toBe(true);
+    const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.status).toBe("SUCCESS");
+    expect(lastFrame.result?.jikiObject?.value).toBe("h");
+  });
+
+  test("allows all string features when no restrictions", () => {
+    const result = interpret(`
+      let str = "hello";
+      let len = str.length;
+      let first = str.charAt(0);
+    `);
+
+    expect(result.error).toBe(null);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Added string stdlib support for JavaScript interpreter with `length` property and `charAt()` method
- Refactored `executeStdlibMemberExpression.ts` for better code organization

## Changes

### String Stdlib Implementation
- Created `src/javascript/stdlib/strings.ts` with:
  - `length` property - returns number of characters in string
  - `charAt(index)` method - returns character at index, supports negative indices
  - All other string methods return appropriate stub errors
- Integrated with language features for progressive learning
- Added comprehensive test coverage (25 tests)

### Code Refactoring
- Extracted `handleProperty()` helper function for property access
- Extracted `handleMethod()` helper function for method access  
- Extracted `guardNotComputedAccess()` guard function
- Simplified inline functions to use parent scope instead of parameter passing

## Test Plan
- [x] All existing tests pass
- [x] Added 25 new tests for string properties and methods
- [x] Tested language feature restrictions work correctly
- [x] Verified error handling for stub methods

🤖 Generated with Claude Code